### PR TITLE
Fix signing for non-MASP IBC Transfers

### DIFF
--- a/app/src/crypto.c
+++ b/app/src/crypto.c
@@ -411,7 +411,7 @@ zxerr_t crypto_sign(const parser_tx_t *txObj, uint8_t *output, uint16_t outputLe
     signature_section.hashes.hashesLen += 2;
 
     // Include Masp hash in the signature if it's there
-    if (txObj->transaction.isMasp) {
+    if ((txObj->typeTx == Transfer && txObj->transfer.has_shielded_hash) || (txObj->typeTx == IBC && txObj->ibc.transfer.has_shielded_hash)) {
 #if !defined(APP_TESTING)
         if (get_state() != STATE_EXTRACT_SPENDS) {
             return zxerr_unknown;

--- a/app/src/parser_impl.c
+++ b/app/src/parser_impl.c
@@ -27,9 +27,7 @@ parser_error_t _read(parser_context_t *ctx, parser_tx_t *v) {
 
     CHECK_ERROR(validateTransactionParams(v))
 
-    if(ctx->tx_obj->transaction.isMasp || ctx->tx_obj->ibc.is_ibc) {
-        CHECK_ERROR(verifyShieldedHash(ctx))
-    }
+    CHECK_ERROR(verifyShieldedHash(ctx))
 
     if (ctx->offset != ctx->bufferLen) {
         return parser_unexpected_unparsed_bytes;
@@ -51,7 +49,7 @@ parser_error_t getNumItems(const parser_context_t *ctx, uint8_t *numItems) {
             break;
 
         case Transfer:
-            if(ctx->tx_obj->transaction.isMasp) {
+            if(ctx->tx_obj->transfer.has_shielded_hash) {
                 uint8_t items = 1;
                 items += 3 * ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_outputs; // print from outputs
                 items += 3 * ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_spends; // print from spends
@@ -130,7 +128,7 @@ parser_error_t getNumItems(const parser_context_t *ctx, uint8_t *numItems) {
 
         case IBC:
             *numItems = (app_mode_expert() ?  IBC_EXPERT_PARAMS : IBC_NORMAL_PARAMS);
-            if(ctx->tx_obj->transaction.isMasp) {
+            if(ctx->tx_obj->ibc.transfer.has_shielded_hash) {
                 *numItems += 3 * ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_outputs; // print from outputs
                 *numItems += 3 * ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_spends; // print from spends
             }

--- a/app/src/parser_print_txn.c
+++ b/app/src/parser_print_txn.c
@@ -174,8 +174,8 @@ static parser_error_t printTransferTxn( const parser_context_t *ctx,
     // Get pointer to the outputs
     bytes_t out = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.outputs;
     // Compute number of spends/outs in the builder tx , and number of itemns to be printer for each
-    uint32_t n_spends = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_spends * (uint32_t) ctx->tx_obj->transaction.isMasp;
-    uint32_t n_outs = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_outputs * (uint32_t) ctx->tx_obj->transaction.isMasp;
+    uint32_t n_spends = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_spends * (uint32_t) ctx->tx_obj->transfer.has_shielded_hash;
+    uint32_t n_outs = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_outputs * (uint32_t) ctx->tx_obj->transfer.has_shielded_hash;
     uint16_t spend_index = 0;
     uint16_t out_index = 0;
 
@@ -1132,8 +1132,8 @@ static parser_error_t printIBCTxn( const parser_context_t *ctx,
     // Get pointer to the outputs
     bytes_t out = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.outputs;
     // Compute number of spends/outs in the builder tx , and number of itemns to be printer for each
-    uint32_t n_spends = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_spends * (uint32_t) ctx->tx_obj->transaction.isMasp;
-    uint32_t n_outs = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_outputs * (uint32_t) ctx->tx_obj->transaction.isMasp;
+    uint32_t n_spends = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_spends * (uint32_t) ctx->tx_obj->ibc.transfer.has_shielded_hash;
+    uint32_t n_outs = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_outputs * (uint32_t) ctx->tx_obj->ibc.transfer.has_shielded_hash;
     uint16_t spend_index = 0;
     uint16_t out_index = 0;
 
@@ -1445,8 +1445,8 @@ static parser_error_t printNFTIBCTxn( const parser_context_t *ctx,
     // Get pointer to the outputs
     bytes_t out = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.outputs;
     // Compute number of spends/outs in the builder tx , and number of itemns to be printer for each
-    uint32_t n_spends = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_spends * (uint32_t) ctx->tx_obj->transaction.isMasp;
-    uint32_t n_outs = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_outputs * (uint32_t) ctx->tx_obj->transaction.isMasp;
+    uint32_t n_spends = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_spends * (uint32_t) ctx->tx_obj->ibc.transfer.has_shielded_hash;
+    uint32_t n_outs = ctx->tx_obj->transaction.sections.maspBuilder.builder.sapling_builder.n_outputs * (uint32_t) ctx->tx_obj->ibc.transfer.has_shielded_hash;
     uint16_t spend_index = 0;
     uint16_t out_index = 0;
 

--- a/app/src/parser_txdef.h
+++ b/app/src/parser_txdef.h
@@ -280,7 +280,8 @@ typedef struct {
     header_t header;
     sections_t sections;
     uint8_t maspTx_idx;
-    bool isMasp;
+    bool hasMaspTx;
+    bool hasMaspBuilder;
 } transaction_t;
 
 


### PR DESCRIPTION
An attempt to resolve https://github.com/Zondax/ledger-namada/issues/88 and enable the testing of IBC transactions in https://github.com/anoma/namada/pull/3797 . Essentially enforces the following conditions:
* MASP Transactions must accompany MASP Transfers.
* MASP Builders must accompany MASP Transactions.
* Only sign displayed sections.
* Support signing non-MASP IBC Transfers.